### PR TITLE
Plumb exit code from pwsh through execute_powershell

### DIFF
--- a/WindowsCMake/MidlRT.cmake
+++ b/WindowsCMake/MidlRT.cmake
@@ -37,12 +37,19 @@ set(MDMERGE_PLATFORM_RESPONSE_FILE "${CMAKE_BINARY_DIR}/mdmerge.platform.rsp")
 
 # Read the PLATFORM_REFERENCES from the WINDOWS_KITS_PLATFORM_PATH file.
 execute_powershell("
+$ErrorActionPreference = 'Stop'
 [xml]$Platform = Get-Content \"${WINDOWS_KITS_PLATFORM_PATH}\"
 $Platform.ApplicationPlatform.ContainedApiContracts.ApiContract |
     ForEach-Object { $_.name, $_.version }
 "
-    OUTPUT_VARIABLE PLATFORM_REFERENCES)
-string(REPLACE "\n" ";" PLATFORM_REFERENCES ${PLATFORM_REFERENCES})
+    OUTPUT_VARIABLE PLATFORM_REFERENCES
+    RESULT_VARIABLE POWERSHELL_RESULT
+    )
+if(NOT (POWERSHELL_RESULT STREQUAL "0"))
+    message(FATAL_ERROR "Unable to load: ${WINDOWS_KITS_PLATFORM_PATH}")
+endif()
+
+string(REPLACE "\n" ";" PLATFORM_REFERENCES "${PLATFORM_REFERENCES}")
 
 while(PLATFORM_REFERENCES)
     list(POP_FRONT PLATFORM_REFERENCES PLATFORM_REFERENCE_NAME)

--- a/WindowsCMake/PowerShell.cmake
+++ b/WindowsCMake/PowerShell.cmake
@@ -33,18 +33,19 @@ include("${CMAKE_CURRENT_LIST_DIR}/WindowsCMakeCommon.cmake")
         execute_powershell(
             <script>
             [OUTPUT_VARIABLE <variable name>]
+            [RESULT_VARIABLE <variable name>]
         )
 ====================================================================================================================]]#
 function(execute_powershell INLINE_SCRIPT)
     windowscmake_find_powershell(POWERSHELL_PATH)
 
-    set(OPTIONS)
-    set(ONE_VALUE_KEYWORDS OUTPUT_VARIABLE)
-    set(MULTI_VALUE_KEYWORDS)
-
     if(NOT INLINE_SCRIPT)
         message(FATAL_ERROR "No script was specified.")
     endif()
+
+    set(OPTIONS)
+    set(ONE_VALUE_KEYWORDS OUTPUT_VARIABLE RESULT_VARIABLE)
+    set(MULTI_VALUE_KEYWORDS)
 
     cmake_parse_arguments(PARSE_ARGV 0 EXECUTE_POWERSHELL "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}")
 
@@ -56,12 +57,18 @@ function(execute_powershell INLINE_SCRIPT)
         COMMAND ${POWERSHELL_COMMAND}
         OUTPUT_VARIABLE POWERSHELL_OUTPUT
         ERROR_VARIABLE POWERSHELL_ERROR
+        RESULT_VARIABLE POWERSHELL_RESULT
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     message(VERBOSE "POWERSHELL_OUTPUT = ${POWERSHELL_OUTPUT}")
     message(VERBOSE "POWERSHELL_ERROR = ${POWERSHELL_ERROR}")
+    message(VERBOSE "POWERSHELL_RESULT = ${POWERSHELL_RESULT}")
 
     if(EXECUTE_POWERSHELL_OUTPUT_VARIABLE)
         set(${EXECUTE_POWERSHELL_OUTPUT_VARIABLE} "${POWERSHELL_OUTPUT}" PARENT_SCOPE)
+    endif()
+
+    if(EXECUTE_POWERSHELL_RESULT_VARIABLE)
+        set(${EXECUTE_POWERSHELL_RESULT_VARIABLE} "${POWERSHELL_RESULT}" PARENT_SCOPE)
     endif()
 endfunction()


### PR DESCRIPTION
As called out in #5, the error handling from `execute_powershell` isn't really sufficient - plumbing through the exit code would help. As per [the documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.3):

> the value 1 is returned when a script-terminating (runspace-terminating) error, such as a throw or -ErrorAction Stop

So this change;
1. Plumbs the pwsh exit code out of `execute_powershell` to the caller
2. Modifies the script to `execute_powershell` to set `$ErrorActionPreference = 'Stop'` - to force errors to be script-terminating.
3. Acts upon the exit code from `execute_powershell` to fail sooner and more clearly.