### PR TITLE
Fix CI builds: Install Ninja in '.github/workflows/ci.yaml'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,10 @@ jobs:
           fetch-depth: 0
           lfs: true
           submodules: true
+      - name: Install Ninja
+        shell: pwsh
+        run: |
+          choco install ninja
       - name: CMake Configure ${{ matrix.buildPreset }}
         shell: pwsh
         run: |


### PR DESCRIPTION
Recent GitHub Agents don't have Ninja installed by default. This change modifies '.github/workflows/ci.yaml' to 'choco install ninja'.