### PR TITLE
'add_import_library' should create a 'SHARED IMPORTED' library, not an 'INTERFACE' library

### DIFF
--- a/WindowsCMake/Imports.cmake
+++ b/WindowsCMake/Imports.cmake
@@ -105,16 +105,10 @@ function(add_import_library TARGET_NAME)
         COMMENT "Generating ${TARGET_NAME}_library"
     )
 
-    add_library(${TARGET_NAME}
-        INTERFACE
-    )
+    add_library(${TARGET_NAME} SHARED IMPORTED)
 
-    add_dependencies(${TARGET_NAME}
-        ${TARGET_NAME}_library
-    )
-
-    target_link_libraries(${TARGET_NAME}
-        INTERFACE
-            ${LIB_FILE_PATH}
+    set_target_properties(${TARGET_NAME}
+        PROPERTIES
+            IMPORTED_IMPLIB ${LIB_FILE_PATH}
     )
 endfunction()


### PR DESCRIPTION
`add_import_library` creates an `INTERFACE` library, but a `SHARED IMPORTED` library would standardize more properties.