### PR TITLE
add_import_library should create a GLOBAL IMPORTED library

### DIFF
--- a/WindowsCMake/Imports.cmake
+++ b/WindowsCMake/Imports.cmake
@@ -105,7 +105,7 @@ function(add_import_library TARGET_NAME)
         COMMENT "Generating ${TARGET_NAME}_library"
     )
 
-    add_library(${TARGET_NAME} SHARED IMPORTED)
+    add_library(${TARGET_NAME} SHARED IMPORTED GLOBAL)
 
     set_target_properties(${TARGET_NAME}
         PROPERTIES


### PR DESCRIPTION
#13 changed `add_import_library` to create a `SHARED IMPORTED` library by default. But `IMPORTED` libraries don't have the same default scope as `INTERFACE` libraries - they are scoped to the current directory and below. By adding `GLOBAL` to the `add_library` call, the `SHARED IMPORTED` library will have the same scope as before.