### PR TITLE
Imports.cmake should work with a MSVC front-end

### DIFF
--- a/WindowsCMake/Imports.cmake
+++ b/WindowsCMake/Imports.cmake
@@ -44,8 +44,8 @@ include_guard()
 ====================================================================================================================]]#
 function(add_import_library TARGET_NAME)
 
-    if((NOT(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")) AND (NOT(CMAKE_C_COMPILER_ID STREQUAL "MSVC")))
-        message(FATAL_ERROR "add_import_library only works with an MSVC compiler.")
+    if((NOT(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")) AND (NOT(CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")))
+        message(FATAL_ERROR "add_import_library only works with an MSVC compiler front-end.")
     endif()
 
     set(OPTIONS)

--- a/WindowsCMake/Imports.cmake
+++ b/WindowsCMake/Imports.cmake
@@ -48,6 +48,14 @@ function(add_import_library TARGET_NAME)
         message(FATAL_ERROR "add_import_library only works with an MSVC compiler front-end.")
     endif()
 
+    if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "17.0"))
+        message(FATAL_ERROR "add_import_library only works with Clang version 17.0 and later")
+    endif()
+
+    if((CMAKE_C_COMPILER_ID STREQUAL "Clang") AND (CMAKE_C_COMPILER_VERSION VERSION_LESS "17.0"))
+        message(FATAL_ERROR "add_import_library only works with Clang version 17.0 and later")
+    endif()
+
     set(OPTIONS)
     set(ONE_VALUE_KEYWORDS NAME)
     set(MULTI_VALUE_KEYWORDS EXPORTS)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -22,7 +22,7 @@ add_subdirectory(CommandLine)
 add_subdirectory(SharedLibrary)
 add_subdirectory(WindowsApplication)
 
-if((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") AND (NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL x86)))
+if((CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC") AND (NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL x86)))
     add_subdirectory(CommandLineImportLibrary)
 endif()
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -22,7 +22,10 @@ add_subdirectory(CommandLine)
 add_subdirectory(SharedLibrary)
 add_subdirectory(WindowsApplication)
 
-if((CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC") AND (NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL x86)))
+if((CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+    AND (NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL x86))
+    AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "17.0"))
     add_subdirectory(CommandLineImportLibrary)
 endif()
 

--- a/example/CommandLineImportLibrary/main.cpp
+++ b/example/CommandLineImportLibrary/main.cpp
@@ -27,7 +27,7 @@ int main(int /*argc*/, char** /*argv*/)
     {
         try
         {
-            std::cout << "Found NtCreateFile: " << &NtCreateFile;
+            std::cout << "Found NtCreateFile: " << reinterpret_cast<void*>(&NtCreateFile);
         }
         catch (const std::exception& ex)
         {


### PR DESCRIPTION
Imports.cmake uses `CMAKE_AR` assuming that it's a MSVC linker (`link.exe`), and attempts to enforce this by checking the `CMAKE_CXX_COMPILER_ID` or `CMAKE_C_COMPILER_ID`. But this fails with `clang-cl.exe`. This change loosens the restrictions by just checking the `CMAKE_CXX_COMPILER_FRONTEND_VARIANT` or `CMAKE_C_COMPILER_FRONTEND_VARIANT` - which is `MSVC` when using MSVC's `cl.exe` or Clang's `clang-cl.exe`, and in both cases, `link.exe` is the linker. I imagine that somehow checking CMAKE_AR to see if it is `link.exe` might be the more right thing to do, but checking the `COMPILER_FRONTEND_VARIANT` seems to be a more direct, less heuristicy approach for the time being.