### PR TITLE
Fix the 'CPPWINRT_DEPENDS' in 'add_cppwinrt_projection'

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -28,7 +28,7 @@ markup:
 lint:
   argument_var_pattern: '([A-Z][A-Z0-9_]+|[a-z_][a-z0-9_]+)'
   local_var_pattern: '[A-Z][A-Z0-9_]+'
-  max_statements: 60
+  max_statements: 80
   disabled_codes:
     # Disable "Line too long", the current documentation tables have long lines.
     - C0301

--- a/WindowsCMake/CppWinRT.cmake
+++ b/WindowsCMake/CppWinRT.cmake
@@ -202,7 +202,7 @@ function(add_cppwinrt_projection TARGET_NAME)
     #   * local
     #   * sdk[+]
     #   * 10.0.12345.0[+]
-    # add it as a dependency.
+    # add it as a dependency. If the item is a folder, add the recursively glob'd '*.winmd' files as dependencies.
     set(CPPWINRT_DEPENDS)
     foreach(CPPWINRT_INPUT IN LISTS CPPWINRT_INPUTS)
         if((CPPWINRT_INPUT STREQUAL "local") OR
@@ -211,6 +211,14 @@ function(add_cppwinrt_projection TARGET_NAME)
             message(VERBOSE "add_cppwinrt_projection: CPPWINRT_INPUT = ${CPPWINRT_INPUT}")
             continue()
         endif()
+
+        if(IS_DIRECTORY "${CPPWINRT_INPUT}")
+            file(GLOB_RECURSE CPPWINRT_INPUT_GLOB "${CPPWINRT_INPUT}/*.winmd")
+            message(VERBOSE "add_cppwinrt_projection: CPPWINRT_INPUT = ${CPPWINRT_INPUT_GLOB} (dependency)")
+            list(APPEND CPPWINRT_DEPENDS ${CPPWINRT_INPUT_GLOB})
+            continue()
+        endif()
+
         message(VERBOSE "add_cppwinrt_projection: CPPWINRT_INPUT = ${CPPWINRT_INPUT} (dependency)")
         list(APPEND CPPWINRT_DEPENDS ${CPPWINRT_INPUT})
     endforeach()


### PR DESCRIPTION
add_cppwinrt_projection adds dependencies to the custom command that generates the CppWinRT projection. If the projection is generated by anything other than 'local', 'sdk' or a specific OS version, then the item itself is added as a dependency. In the past, I've typically use a specific OS version, but have recently switched to use the new support for consuming the 'Microsoft.Windows.SDK.Contracts' NuGet. In this case, the folder within the NuGet is specified as the dependency, and the Visual Studio generator doesn't like that - and I think it's right - so logs a warning. The Ninja generator doesn't complain. To appease the Visual Studio generator, and to do the Right Thing, if the given input is a folder, then we add the recursively glob'd *.winmd files as dependencies (since cppwinrt.exe says that it consumes the recursive *.winmd files).