### PR TITLE
Imports.cmake: Add an explicit dependency from '${TARGET_NAME}' to '${TARGET_NAME}_library'

### DIFF
--- a/WindowsCMake/Imports.cmake
+++ b/WindowsCMake/Imports.cmake
@@ -134,6 +134,10 @@ exit /b 0
 
     add_library(${TARGET_NAME} SHARED IMPORTED GLOBAL)
 
+    add_dependencies(${TARGET_NAME}
+        ${TARGET_NAME}_library
+    )
+
     set_target_properties(${TARGET_NAME}
         PROPERTIES
             IMPORTED_IMPLIB ${LIB_FILE_PATH}


### PR DESCRIPTION
`Imports.cmake` creates a custom target to generate the 'import library', and then a 'SHARED IMPORTED GLOBAL' library that depends on the custom target. The shared, imported target sets the 'IMPORTED_IMPLIB' property to the output of the custom target, and for Ninja generators, that's enough for the custom target to be invoked. But with a Visual Studio generator it isn't - the custom target isn't run. Adding an explicit dependency fixes the Visual Studio generator build.