### PR TITLE
Avoid installing ninja in ci.yaml, rely on WindowsToolchain to find the VS version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,10 +72,6 @@ jobs:
           fetch-depth: 0
           lfs: true
           submodules: true
-      - name: Install Ninja
-        shell: pwsh
-        run: |
-          choco install ninja
       - name: CMake Configure ${{ matrix.buildPreset }}
         shell: pwsh
         run: |


### PR DESCRIPTION
WindowsToolchain will - as of [v0.12.0](https://github.com/MarkSchofield/WindowsToolchain/releases/tag/v0.12.0) - find the VS installed Ninja. This means that ci.yaml needn't use Chocolatey to install Ninja - since Ninja is installed with VS - and that saves ~10 to ~40 seconds for every build.