### PR TITLE
Fix the Pester tests

### DIFF
--- a/Tests/Ninja/CMakePresets.json
+++ b/Tests/Ninja/CMakePresets.json
@@ -14,6 +14,7 @@
         "CMAKE_C_COMPILER_FORCED": "true",
         "CMAKE_CXX_COMPILER_FORCED": "true",
         "CMAKE_TOOLCHAIN_FILE": "../../example/WindowsToolchain/Windows.MSVC.toolchain.cmake",
+        "TOOLCHAIN_ADD_VS_NINJA_PATH": "OFF",
         "WINDOWSCMAKE_DIR": "../../WindowsCMake"
       }
     }

--- a/Tests/NuGet/Toolchain.NuGet.Tests.ps1
+++ b/Tests/NuGet/Toolchain.NuGet.Tests.ps1
@@ -61,16 +61,6 @@ Describe 'WindowsCMake NuGet support' {
         }
     }
 
-    It 'does not download NuGet if it is not in the path or specified, and TOOLCHAIN_TOOLS_PATH is not set' {
-        StashEnvironment Path {
-            $env:Path = ''
-
-            # With no NuGet to be found, and TOOLCHAIN_TOOLS_PATH not set, the build should fail.
-            $Null = & $CMake --preset windows 2>&1
-            $LastExitCode | Should -Be 1
-        }
-    }
-
     It 'downloads NuGet if it is not in the path or specified, and TOOLCHAIN_TOOLS_PATH is set' {
         StashEnvironment Path {
             $env:Path = ''


### PR DESCRIPTION
This repo has a handful of tests of the NuGet and Ninja functionality. There were two problems:
    1. The update to WindowsToolchain v0.12.0 broke the Ninja tests since WindowsToolchain can now find Ninja, preventing the WindowsCMake ninja finding logic from running. By opt-ing out of the WindowsToolchain behavior, we can now correctly test the WindowsCMake behavior.
    2. There was a stale test of the NuGet functionality that was passing incorrectly - it should've started failing when the NuGet-download behavior changed. Removing it.