### PR TITLE
Cleanup WinUIApplication - use the bootstrapping code to find the runtime package

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(wil INTERFACE IMPORTED)
 target_include_directories(wil
     INTERFACE
         ${NUGET_MICROSOFT_WINDOWS_IMPLEMENTATIONLIBRARY}/include
-    )
+)
 
 add_subdirectory(CommandLine)
 add_subdirectory(SharedLibrary)

--- a/example/WinUIApplication/CMakeLists.txt
+++ b/example/WinUIApplication/CMakeLists.txt
@@ -3,48 +3,7 @@
 # ----------------------------------------------------------------------------------------------------------------------
 project(WinUIApplication LANGUAGES CXX)
 
-install_nuget_package(Microsoft.Web.WebView2 1.0.2651.64 NUGET_MICROSOFT_WEB_WEBVIEW2
-    PACKAGESAVEMODE nuspec
-)
-
-add_cppwinrt_projection(Microsoft.Web.WebView2.Core
-    INPUTS
-        ${NUGET_MICROSOFT_WEB_WEBVIEW2}/lib/Microsoft.Web.WebView2.Core.winmd
-    DEPS
-        CppWinRT
-    OPTIMIZE
-)
-
-install_nuget_package(Microsoft.WindowsAppSDK 1.6.241114003 NUGET_MICROSOFT_WINDOWSAPPSDK
-    PACKAGESAVEMODE nuspec
-)
-
-add_cppwinrt_projection(Microsoft.WindowsAppSDK
-    INPUTS
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.UI.Text.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.UI.Xaml.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.ApplicationModel.DynamicDependency.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.ApplicationModel.Resources.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.ApplicationModel.WindowsAppRuntime.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.AppLifecycle.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.AppNotifications.Builder.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.AppNotifications.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.Globalization.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.Management.Deployment.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.PushNotifications.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.Security.AccessControl.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.Storage.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.System.Power.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.System.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.Widgets.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0.18362/Microsoft.Foundation.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0.18362/Microsoft.Graphics.winmd
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0.18362/Microsoft.UI.winmd
-    DEPS
-        CppWinRT
-        Microsoft.Web.WebView2.Core
-    OPTIMIZE
-)
+include(Dependencies.cmake)
 
 add_executable(WinUIApplication WIN32
     WinUIApplication.exe.manifest
@@ -55,11 +14,6 @@ add_executable(WinUIApplication WIN32
 target_compile_features(WinUIApplication
     PRIVATE
         cxx_std_20
-)
-
-target_include_directories(WinUIApplication
-    PRIVATE
-        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/include
 )
 
 target_precompile_headers(WinUIApplication
@@ -77,4 +31,10 @@ target_link_libraries(WinUIApplication
 set_source_files_properties(WinUIApplication.rc
     PROPERTIES
     OBJECT_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/small.ico;${CMAKE_CURRENT_LIST_DIR}/WinUIApplication.ico"
+)
+
+add_custom_command(TARGET WinUIApplication POST_BUILD
+    COMMAND "${CMAKE_COMMAND};-E;$<IF:$<BOOL:$<TARGET_RUNTIME_DLLS:WinUIApplication>>,copy;$<TARGET_RUNTIME_DLLS:WinUIApplication>;$<TARGET_FILE_DIR:WinUIApplication>,true>"
+    COMMAND_EXPAND_LISTS
+    COMMENT "Copying runtime dependencies"
 )

--- a/example/WinUIApplication/Dependencies.cmake
+++ b/example/WinUIApplication/Dependencies.cmake
@@ -1,0 +1,78 @@
+# ----------------------------------------------------------------------------------------------------------------------
+#
+# ----------------------------------------------------------------------------------------------------------------------
+
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL AMD64)
+    set(RUNTIME_IDENTIFIER x64)
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL ARM64)
+    set(RUNTIME_IDENTIFIER arm64)
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL X86)
+    set(RUNTIME_IDENTIFIER x86)
+else()
+    message(FATAL_ERROR "Unable to identify the runtime identifier from CMAKE_SYSTEM_PROCESSOR ${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
+
+# Add the 'Microsoft.Web.WebView2.Core' target
+#
+install_nuget_package(Microsoft.Web.WebView2 1.0.2651.64 NUGET_MICROSOFT_WEB_WEBVIEW2
+    PACKAGESAVEMODE nuspec
+)
+
+add_cppwinrt_projection(Microsoft.Web.WebView2.Core
+    INPUTS
+        ${NUGET_MICROSOFT_WEB_WEBVIEW2}/lib/Microsoft.Web.WebView2.Core.winmd
+    DEPS
+        CppWinRT
+    OPTIMIZE
+)
+
+# Add the 'Microsoft.WindowsAppRuntime' and 'Microsoft.WindowsAppSDK' targets
+#
+install_nuget_package(Microsoft.WindowsAppSDK 1.6.241114003 NUGET_MICROSOFT_WINDOWSAPPSDK
+    PACKAGESAVEMODE nuspec
+)
+
+add_library(Microsoft.WindowsAppRuntime SHARED IMPORTED)
+
+set_target_properties(Microsoft.WindowsAppRuntime PROPERTIES
+    IMPORTED_IMPLIB ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/win10-${RUNTIME_IDENTIFIER}/Microsoft.WindowsAppRuntime.Bootstrap.lib
+    IMPORTED_LOCATION ${NUGET_MICROSOFT_WINDOWSAPPSDK}/runtimes/win-${RUNTIME_IDENTIFIER}/native/Microsoft.WindowsAppRuntime.Bootstrap.dll
+)
+
+add_cppwinrt_projection(Microsoft.WindowsAppSDK
+    INPUTS
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.UI.Text.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.UI.Xaml.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.ApplicationModel.DynamicDependency.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.ApplicationModel.Resources.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.ApplicationModel.WindowsAppRuntime.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.AppLifecycle.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.AppNotifications.Builder.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.AppNotifications.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.Globalization.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.Management.Deployment.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.PushNotifications.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.Security.AccessControl.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.Storage.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.System.Power.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.System.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0/Microsoft.Windows.Widgets.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0.18362/Microsoft.Foundation.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0.18362/Microsoft.Graphics.winmd
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/lib/uap10.0.18362/Microsoft.UI.winmd
+    DEPS
+        CppWinRT
+        Microsoft.Web.WebView2.Core
+    OPTIMIZE
+)
+
+target_include_directories(Microsoft.WindowsAppSDK
+    INTERFACE
+        ${NUGET_MICROSOFT_WINDOWSAPPSDK}/include
+)
+
+target_link_libraries(Microsoft.WindowsAppSDK
+    INTERFACE
+        Microsoft.WindowsAppRuntime
+)


### PR DESCRIPTION
A couple of improvements to WinUIApplication:
1. Move the WinAppSDK targets into a separate Dependencies.cmake and better encapsulate them.
2. Replace the code to explicitly add the WinAppSDK runtime package dependency with the use of 'Microsoft::Windows::ApplicationModel::DynamicDependency::Bootstrap::Initialize'. Since this adds a DLL dependency - 'Microsoft.WindowsAppRuntime.Bootstrap.dll' - add logic to WinUIApplication to copy 'TARGET_RUNTIME_DLLS' into 'TARGET_FILE_DIR' during the build.