### PR TITLE
Mark CppWinRT include paths as 'SYSTEM'

### DIFF
--- a/WindowsCMake/CppWinRT.cmake
+++ b/WindowsCMake/CppWinRT.cmake
@@ -235,7 +235,7 @@ function(add_cppwinrt_projection TARGET_NAME)
         ${CPPWINRT_OUTPUT_FILE}
     )
 
-    target_include_directories(${TARGET_NAME} BEFORE
+    target_include_directories(${TARGET_NAME} SYSTEM BEFORE
         INTERFACE
             ${CPPWINRT_OUTPUT}
     )


### PR DESCRIPTION
CppWinRT files are added through `target_include_directories` and as a result are considered as 'non-platform' dependencies for, say, clang-tidy analysis. But they are 'platform' pieces or define the contract of non-local component, so marking them as SYSTEM seems like a better classification.