### PR TITLE
Canonicalize post-build steps for copying 'TARGET_RUNTIME_DLLS'

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -5,6 +5,14 @@ cmake_minimum_required(VERSION 3.20)
 
 project(WindowsCMakeExample)
 
+macro(post_build_copy_runtime_dlls TARGET)
+    add_custom_command(TARGET ${TARGET} POST_BUILD
+    COMMENT "Copying '${TARGET}' dependencies"
+    COMMAND "${CMAKE_COMMAND};-E;$<IF:$<BOOL:$<TARGET_RUNTIME_DLLS:${TARGET}>>,copy;$<TARGET_RUNTIME_DLLS:${TARGET}>;$<TARGET_FILE_DIR:${TARGET}>,true>"
+    COMMAND_EXPAND_LISTS
+    )
+endmacro()
+
 include(${WINDOWSCMAKE_DIR}/CppWinRT.cmake)
 
 add_cppwinrt_projection(CppWinRT

--- a/example/CommandLine/CMakeLists.txt
+++ b/example/CommandLine/CMakeLists.txt
@@ -7,3 +7,5 @@ add_executable(CommandLine
     main.cpp
 )
 
+# Add a 'post build' step to copy 'TARGET_RUNTIME_DLLS' into the 'TARGET_FILE_DIR'.
+post_build_copy_runtime_dlls(CommandLine)

--- a/example/CommandLineImportLibrary/CMakeLists.txt
+++ b/example/CommandLineImportLibrary/CMakeLists.txt
@@ -23,3 +23,6 @@ target_link_libraries(CommandLineImportLibrary
     PRIVATE
         ntdll_imports
 )
+
+# Add a 'post build' step to copy 'TARGET_RUNTIME_DLLS' into the 'TARGET_FILE_DIR'.
+post_build_copy_runtime_dlls(CommandLineImportLibrary)

--- a/example/CommandLineWinRT/CMakeLists.txt
+++ b/example/CommandLineWinRT/CMakeLists.txt
@@ -22,8 +22,5 @@ target_link_libraries(CommandLineWinRT
         RuntimeComponentCppWinRT
 )
 
-add_custom_command(TARGET CommandLineWinRT POST_BUILD
-  COMMENT "Copying 'CommandLineWinRT' dependencies"
-  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:CommandLineWinRT> $<TARGET_FILE_DIR:CommandLineWinRT>
-  COMMAND_EXPAND_LISTS
-)
+# Add a 'post build' step to copy 'TARGET_RUNTIME_DLLS' into the 'TARGET_FILE_DIR'.
+post_build_copy_runtime_dlls(CommandLineWinRT)

--- a/example/WinUIApplication/CMakeLists.txt
+++ b/example/WinUIApplication/CMakeLists.txt
@@ -33,8 +33,5 @@ set_source_files_properties(WinUIApplication.rc
     OBJECT_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/small.ico;${CMAKE_CURRENT_LIST_DIR}/WinUIApplication.ico"
 )
 
-add_custom_command(TARGET WinUIApplication POST_BUILD
-    COMMAND "${CMAKE_COMMAND};-E;$<IF:$<BOOL:$<TARGET_RUNTIME_DLLS:WinUIApplication>>,copy;$<TARGET_RUNTIME_DLLS:WinUIApplication>;$<TARGET_FILE_DIR:WinUIApplication>,true>"
-    COMMAND_EXPAND_LISTS
-    COMMENT "Copying runtime dependencies"
-)
+# Add a 'post build' step to copy 'TARGET_RUNTIME_DLLS' into the 'TARGET_FILE_DIR'.
+post_build_copy_runtime_dlls(WinUIApplication)

--- a/example/WindowsApplication/CMakeLists.txt
+++ b/example/WindowsApplication/CMakeLists.txt
@@ -12,3 +12,6 @@ set_source_files_properties(WindowsApplication.rc
     PROPERTIES
         OBJECT_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/small.ico;${CMAKE_CURRENT_LIST_DIR}/WindowsApplication.ico"
 )
+
+# Add a 'post build' step to copy 'TARGET_RUNTIME_DLLS' into the 'TARGET_FILE_DIR'.
+post_build_copy_runtime_dlls(WindowsApplication)


### PR DESCRIPTION
Cleanup the 'examples' by defining a `post_build_copy_runtime_dlls`-macro that performs the copy of `TARGET_RUNTIME_DLLS` to `TARGET_FILE_DIR` for the given target.