### PR TITLE
Support more clang-format file extensions

### DIFF
--- a/WindowsCMake/ClangFormat.cmake
+++ b/WindowsCMake/ClangFormat.cmake
@@ -54,8 +54,17 @@ function(add_clang_format)
         )
     endif()
 
+    if(NOT (DEFINED CLANG_FORMAT_FILE_EXTENSIONS))
+        set(CLANG_FORMAT_FILE_EXTENSIONS ${CMAKE_CXX_SOURCE_FILE_EXTENSIONS})
+        list(APPEND CLANG_FORMAT_FILE_EXTENSIONS ${CMAKE_C_SOURCE_FILE_EXTENSIONS})
+        list(APPEND CLANG_FORMAT_FILE_EXTENSIONS h H hpp HPP hxx HXX)
+    endif()
+
+    list(TRANSFORM CLANG_FORMAT_FILE_EXTENSIONS PREPEND "*.")
+    list(JOIN CLANG_FORMAT_FILE_EXTENSIONS " " CLANG_FORMAT_WILDCARDS)
+
     set(CLANG_FORMAT_COMMAND "              \
-git ls-files *.h *.cpp |                    \
+git ls-files ${CLANG_FORMAT_WILDCARDS} |    \
     ForEach-Object -Parallel {              \
         & '${CLANG_FORMAT_PATH}' -i $$_     \
     }                                       \


### PR DESCRIPTION
The 'clang-format' task will format C and C++ files in the repository. It was just looking for `*.h` and `*.cpp` files - but there's more options than that. This change supports callers setting `CLANG_FORMAT_FILE_EXTENSIONS` containing a list of file extensions to format, or defaults to the `CMAKE_CXX_SOURCE_FILE_EXTENSIONS`, `CMAKE_C_SOURCE_FILE_EXTENSIONS` and a set of common header-file extensions.