### PR TITLE
CMake fails to 'execute_process' when the System folder isn't in the path

### DIFF
--- a/Tests/Ninja/Toolchain.Ninja.Tests.ps1
+++ b/Tests/Ninja/Toolchain.Ninja.Tests.ps1
@@ -22,6 +22,10 @@ AfterAll {
 
 Describe 'WindowsCMake Ninja support' {
     BeforeEach {
+        $DefaultParameters = @(
+            '--log-level=VERBOSE'
+        )
+
         # Make sure that the build is clean before each test
         @(
             $ToolsPath
@@ -36,7 +40,7 @@ Describe 'WindowsCMake Ninja support' {
             "-DCMAKE_MAKE_PROGRAM=$DownloadNinjaPath"
         )
 
-        $Null = & $CMake --preset windows @Parameters
+        $Null = & $CMake --preset windows @DefaultParameters @Parameters 2>&1
         $LastExitCode | Should -Be 0
 
         $CMakeCachePath = Join-Path -Path $OutputPath -ChildPath windows/CMakeCache.txt
@@ -46,8 +50,8 @@ Describe 'WindowsCMake Ninja support' {
 
     It 'does not download Ninja if it is in the path' {
         StashEnvironment Path {
-            $env:Path = $DownloadPath
-            $Null = & $CMake --preset windows
+            $env:Path = [System.Environment]::SystemDirectory + ';' + $DownloadPath
+            $Null = & $CMake --preset windows @DefaultParameters 2>&1
             $LastExitCode | Should -Be 0
 
             $CMakeCachePath = Join-Path -Path $OutputPath -ChildPath windows/CMakeCache.txt
@@ -64,24 +68,24 @@ Describe 'WindowsCMake Ninja support' {
 
     It 'does not download Ninja if it is not in the path or specified, and TOOLCHAIN_TOOLS_PATH is not set' {
         StashEnvironment Path {
-            $env:Path = ''
+            $env:Path = [System.Environment]::SystemDirectory
 
             # With no Ninja to be found, and TOOLCHAIN_TOOLS_PATH not set, the build should fail.
-            $Null = & $CMake --preset windows 2>&1
+            $Null = & $CMake --preset windows @DefaultParameters 2>&1
             $LastExitCode | Should -Be 1
         }
     }
 
     It 'downloads Ninja if it is not in the path or specified, and TOOLCHAIN_TOOLS_PATH is set' {
         StashEnvironment Path {
-            $env:Path = ''
+            $env:Path = [System.Environment]::SystemDirectory
 
             # With no Ninja to be found, but with TOOLCHAIN_TOOLS_PATH set, the build should succeed.
             $Parameters = @(
                 "-DTOOLCHAIN_TOOLS_PATH=$ToolsPath"
             )
 
-            $Null = & $CMake --preset windows @Parameters
+            $Null = & $CMake --preset windows @DefaultParameters @Parameters 2>&1
             $LastExitCode | Should -Be 0
 
             $CMakeCachePath = Join-Path -Path $OutputPath -ChildPath windows/CMakeCache.txt

--- a/Tests/NuGet/Toolchain.NuGet.Tests.ps1
+++ b/Tests/NuGet/Toolchain.NuGet.Tests.ps1
@@ -37,7 +37,7 @@ Describe 'WindowsCMake NuGet support' {
             "-DTOOLCHAIN_TOOLS_PATH=$ToolsPath"
         )
 
-        $Null = & $CMake --preset windows @Parameters
+        $Null = & $CMake --preset windows @Parameters 2>&1
         $LastExitCode | Should -Be 0
 
         $CMakeCachePath = Join-Path -Path $OutputPath -ChildPath windows/CMakeCache.txt
@@ -51,8 +51,8 @@ Describe 'WindowsCMake NuGet support' {
                 "-DTOOLCHAIN_TOOLS_PATH=$ToolsPath"
             )
 
-            $env:Path = $DownloadPath
-            $Null = & $CMake --preset windows @Parameters --log-level=verbose
+            $env:Path = [System.Environment]::SystemDirectory + ';' + $DownloadPath
+            $Null = & $CMake --preset windows @Parameters --log-level=verbose 2>&1
             $LastExitCode | Should -Be 0
 
             $CMakeCachePath = Join-Path -Path $OutputPath -ChildPath windows/CMakeCache.txt
@@ -63,14 +63,14 @@ Describe 'WindowsCMake NuGet support' {
 
     It 'downloads NuGet if it is not in the path or specified, and TOOLCHAIN_TOOLS_PATH is set' {
         StashEnvironment Path {
-            $env:Path = ''
+            $env:Path = [System.Environment]::SystemDirectory
 
             # With no NuGet to be found, but with TOOLCHAIN_TOOLS_PATH set, the build should succeed.
             $Parameters = @(
                 "-DTOOLCHAIN_TOOLS_PATH=$ToolsPath"
             )
 
-            $Null = & $CMake --preset windows @Parameters
+            $Null = & $CMake --preset windows @Parameters 2>&1
             $LastExitCode | Should -Be 0
 
             $CMakeCachePath = Join-Path -Path $OutputPath -ChildPath windows/CMakeCache.txt
@@ -95,7 +95,7 @@ Describe 'WindowsCMake NuGet support' {
             "-DSPECIFIED_PACKAGESAVEMODE=nuspec"
         )
 
-        $Null = & $CMake --preset windows @Parameters
+        $Null = & $CMake --preset windows @Parameters 2>&1
         $LastExitCode | Should -Be 0
 
         Join-Path $OutputPath 'windows/__nuget/Humanizer.Core.2.14.1/Humanizer.Core.nuspec' |


### PR DESCRIPTION
The Pester tests are failing with a more recent version of CMake. 5 of the Pester tests clear the PATH environment variable before invoking CMake to ensure that functionality is correct when a minimal PATH is used. But more recent versions of CMake fail to create processes with `execute_process` when the System folder (e.g. C:\Windows\System32) isn't in the path. This PR updates the tests so that the system folder is included in the minimal PATH.