### PR TITLE
Fixes to ASAN builds

### DIFF
--- a/WindowsCMake/Asan.cmake
+++ b/WindowsCMake/Asan.cmake
@@ -46,6 +46,8 @@ function(windowscmake_add_asan_target)
 
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL AMD64)
         set(ASAN_PLATFORM x86_64)
+    elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL ARM64)
+        set(ASAN_PLATFORM aarch64)
     else()
         set(ASAN_PLATFORM i386)
     endif()

--- a/WindowsCMake/Asan.cmake
+++ b/WindowsCMake/Asan.cmake
@@ -79,17 +79,40 @@ function(windowscmake_add_asan_target)
     set_target_properties(WindowsCMakeAsanRuntime
         PROPERTIES
             FOLDER WindowsCMake
-
-            IMPORTED_IMPLIB_DEBUG ${ASAN_LIB_DEBUG}
-            IMPORTED_IMPLIB_RELEASE ${ASAN_LIB}
-            IMPORTED_IMPLIB_RELWITHDEBINFO ${ASAN_LIB}
-            IMPORTED_IMPLIB_RELMINSIZE ${ASAN_LIB}
-
-            IMPORTED_LOCATION_DEBUG ${ASAN_DLL_DEBUG}
-            IMPORTED_LOCATION_RELEASE ${ASAN_DLL}
-            IMPORTED_LOCATION_RELWITHDEBINFO ${ASAN_DLL}
-            IMPORTED_LOCATION_RELMINSIZE ${ASAN_DLL}
     )
+
+    if(CMAKE_CONFIGURATION_TYPES)
+        foreach(CONFIGURATION_TYPE ${CMAKE_CONFIGURATION_TYPES})
+            string(TOUPPER "${CONFIGURATION_TYPE}" CONFIGURATION_TYPE)
+            if(CONFIGURATION_TYPE STREQUAL "DEBUG")
+                set_target_properties(WindowsCMakeAsanRuntime
+                    PROPERTIES
+                        IMPORTED_IMPLIB_DEBUG ${ASAN_LIB_DEBUG}
+                        IMPORTED_LOCATION_DEBUG ${ASAN_DLL_DEBUG}
+                )
+            else()
+                set_target_properties(WindowsCMakeAsanRuntime
+                    PROPERTIES
+                        IMPORTED_IMPLIB_${CONFIGURATION_TYPE} ${ASAN_LIB}
+                        IMPORTED_LOCATION_${CONFIGURATION_TYPE} ${ASAN_DLL}
+                )
+            endif()
+        endforeach()
+    else()
+        if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+            set_target_properties(WindowsCMakeAsanRuntime
+                PROPERTIES
+                    IMPORTED_IMPLIB ${ASAN_LIB_DEBUG}
+                    IMPORTED_LOCATION ${ASAN_DLL_DEBUG}
+            )
+        else()
+            set_target_properties(WindowsCMakeAsanRuntime
+                PROPERTIES
+                    IMPORTED_IMPLIB ${ASAN_LIB}
+                    IMPORTED_LOCATION ${ASAN_DLL}
+            )
+        endif()
+    endif()
 
     target_link_libraries(WindowsCMakeAsanRuntime
         INTERFACE

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -90,6 +90,34 @@
       }
     },
     {
+      "name": "windows-msvc-arm64+relwithdebinfo+asan",
+      "inherits": ["windows", "+asan"],
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_TOOLCHAIN_FILE": "./Build/WindowsToolchain/Windows.MSVC.toolchain.cmake",
+        "CMAKE_VS_VERSION_PRERELEASE": "ON",
+        "CMAKE_VS_VERSION_RANGE": "[16.0,19.0)",
+        "VS_EXPERIMENTAL_MODULE": "ON",
+        "VS_USE_SPECTRE_MITIGATION_RUNTIME": "OFF",
+        "CMAKE_SYSTEM_PROCESSOR": "ARM64"
+      }
+    },
+    {
+      "name": "windows-msvc-arm64+debug+asan",
+      "inherits": ["windows", "+asan"],
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_TOOLCHAIN_FILE": "./Build/WindowsToolchain/Windows.MSVC.toolchain.cmake",
+        "CMAKE_VS_VERSION_PRERELEASE": "ON",
+        "CMAKE_VS_VERSION_RANGE": "[16.0,19.0)",
+        "VS_EXPERIMENTAL_MODULE": "ON",
+        "VS_USE_SPECTRE_MITIGATION_RUNTIME": "OFF",
+        "CMAKE_SYSTEM_PROCESSOR": "ARM64"
+      }
+    },
+    {
       "name": "windows-clang-x64",
       "inherits": "windows-clang",
       "displayName": "Configure 'windows-clang-x64'",
@@ -141,6 +169,14 @@
       "name": "windows-msvc-x64+asan",
       "configurePreset": "windows-msvc-x64+asan",
       "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "windows-msvc-arm64+relwithdebinfo+asan",
+      "configurePreset": "windows-msvc-arm64+relwithdebinfo+asan"
+    },
+    {
+      "name": "windows-msvc-arm64+debug+asan",
+      "configurePreset": "windows-msvc-arm64+debug+asan"
     },
     {
       "name": "windows-clang-x64+asan",

--- a/example/build.ps1
+++ b/example/build.ps1
@@ -5,8 +5,8 @@
 
 [CmdletBinding()]
 param (
-    [ValidateSet('windows-clang-x64', 'windows-msvc-arm64', 'windows-msvc-x64', 'windows-msvc-x86')]
-    $Presets = @('windows-clang-x64', 'windows-msvc-arm64', 'windows-msvc-x64', 'windows-msvc-x86')
+    [ValidateSet('windows-msvc-x64', 'windows-msvc-x64+asan', 'windows-msvc-x86', 'windows-msvc-arm64', 'windows-msvc-arm64+relwithdebinfo+asan', 'windows-msvc-arm64+debug+asan', 'windows-clang-x64', 'windows-clang-x64+asan', 'windows-clangcl-x64', 'windows-clangcl-x64+asan')]
+    $Presets = @('windows-msvc-x64', 'windows-msvc-x64+asan', 'windows-msvc-x86', 'windows-msvc-arm64', 'windows-msvc-arm64+relwithdebinfo+asan', 'windows-msvc-arm64+debug+asan', 'windows-clang-x64', 'windows-clang-x64+asan', 'windows-clangcl-x64', 'windows-clangcl-x64+asan')
 )
 
 Set-StrictMode -Version Latest


### PR DESCRIPTION
A couple of fixes to ASAN builds:
1. `WindowsCMake/Asan.cmake` incorrectly set `IMPORTED_LOCATION_RELMINSIZE` and `IMPORTED_IMPLIB_RELMINSIZE` properties on the `WindowsCMakeAsanRuntime` target - containing `RELMINSIZE` when it should be `MINSIZEREL`. But there's a more correct fix than addressing the typo:
    1. If `CMAKE_CONFIGURATION_TYPES` is set, use those values to set the `IMPORTED_IMPLIB_${CONFIGURATION_TYPE}` and `IMPORTED_LOCATION_${CONFIGURATION_TYPE}` target properties
    2. If `CMAKE_CONFIGURATION_TYPES` isn't set, set the `IMPORTED_IMPLIB` and `IMPORTED_LOCATION` target properties.
2. `WindowsCMake/Asan.cmake` didn't accommodate a ARM64 builds

This PR fixes both issues, and adds ARM64 presets for the examples, both of which use the 'Ninja' - not 'Ninja Multi-Config' - generator.